### PR TITLE
provide data in case of "fail"

### DIFF
--- a/lib/restler-promise.js
+++ b/lib/restler-promise.js
@@ -32,7 +32,7 @@ module.exports = function (Promise) {
                 });
 
                 request.once('fail', function(data, response) {
-                    reject({ error: new Error(getStatusMessage(response.statusCode)), response: response});
+                    reject({ error: new Error(getStatusMessage(response.statusCode)), response: response, data: data});
                 });
 
                 request.on('error', function(err, response) {


### PR DESCRIPTION
In case of 'fail', restler-promise drops the 'data' result.
This patch provides the 'data' result to the caller.

This should not affect any existing code.

Please let me know if you would like to have the PR differently.